### PR TITLE
Add Azure VM Images list

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,5 @@
 FROM microsoft/azure-cli:2.0.29
 
-COPY bin/AzurePublicIP.sh /listazurepublicips/AzurePublicIP.sh
+WORKDIR /data
 
-WORKDIR /listazurepublicips
-
-ENTRYPOINT ["bash", "AzurePublicIP.sh"]
+ENTRYPOINT ["bash"]

--- a/Makefile
+++ b/Makefile
@@ -1,18 +1,38 @@
-.DEFAULT_GOAL := export-public-ips
+.DEFAULT_GOAL := help
 
 az-docker-run = docker run \
 	--rm \
-	-e APP_ID=$(APP_ID) \
-	-e PASSWORD=$(PASSWORD) \
-	-e TENANT_ID=$(TENANT_ID) \
-	listazurepublicips
+	-v $(shell pwd)/bin:/data \
+	-e AZURE_SERVICE_PRINCIPAL=$(AZURE_SERVICE_PRINCIPAL) \
+	-e AZURE_CLIENT_SECRET=$(AZURE_CLIENT_SECRET) \
+	-e AZURE_TENANT_ID=$(AZURE_TENANT_ID) \
+	azure-tools
 
+.PHONY: export-vm-images
+export-vm-images: setup ## List information about the vm images
+	@$(az-docker-run) \
+		AzureVmImage.sh
 
 .PHONY: export-public-ips
-export-public-ips: setup
-	@$(az-docker-run)
+export-public-ips: setup ## List information about the public ips
+	@$(az-docker-run) \
+		AzurePublicIP.sh
 
+.PHONY: help
+help: ## Show help
+	@IFS=$$'\n' ; \
+	help_lines=(`fgrep -h "##" $(MAKEFILE_LIST) | fgrep -v fgrep | sed -e 's/\\$$//'`); \
+	printf "%-30s %s\n" Target "Help message" ; \
+	printf "%-30s %s\n" ------ ------------ ; \
+	for help_line in $${help_lines[@]}; do \
+		IFS=$$'#' ; \
+		help_split=($$help_line) ; \
+		help_command=`echo $${help_split[0]} | echo $${help_split[0]} | cut -d: -f1` ; \
+		help_info=`echo $${help_split[2]} | sed -e 's/^ *//' -e 's/ *$$//'` ; \
+		printf "%-30s %s\n" $$help_command $$help_info ; \
+	done
 
 .PHONY: setup
-setup:         
-	@docker build . -t listazurepublicips
+setup: ## Build docker image with Azure CLI
+	@docker build . -t azure-tools 1>/dev/null
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# ListAzurePublicIPs
+# AzureTools
 
-The most easy way to get all public IPs from the Azure subscriptions.
+The most easy way to get informations from the Azure subscriptions.
 
 ## Prerequisites
 
@@ -13,13 +13,13 @@ The most easy way to get all public IPs from the Azure subscriptions.
 First of all, export your Azure Service Principal credentials to use this project.
 
 ```bash
-export PASSWORD="XXXXXXX-XXXXXXX-XXXXXXXX-XXXXXXX"
-export TENANT_ID="XXXXXXX-XXXXXXX-XXXXXXXX-XXXXXXX"
-export APP_ID="XXXXXXX-XXXXXXX-XXXXXXXX-XXXXXXX"
+export AZURE_SERVICE_PRINCIPAL="http://awesome-service-principal"
+export AZURE_CLIENT_SECRET="XXXXXXX-XXXXXXX-XXXXXXXX-XXXXXXX"
+export AZURE_TENANT_ID="XXXXXXX-XXXXXXX-XXXXXXXX-XXXXXXX"
 ```
 
 ## Create a environment
- 
+
 Run this command to build your structure
 
 ```bash
@@ -31,17 +31,24 @@ $ make setup
 To get the full information from subscriptions, use this command:
 
 ```bash
-$ make
+$ make export-public-ips
 ```
-
-This command will read all the Subscriptons where the Service Principal has the access.
-
-TIP: Create the Service Principal for this action only with READ permissions.
-
 If you want only the IP list, use this:
 
 ```bash
-$ make | awk -F "," '{print $3}'
+$ make export-public-ips | awk -F "," '{print $3}'
 ```
+
+## Getting the VM Image list
+
+To get the full information from subscriptions, use this command:
+
+```bash
+$ make export-vm-images
+```
+---
+This commands will read all the Subscriptons where the Service Principal has the access.
+
+TIP: Create the Service Principal for this action only with READ permissions.
 
 That's all :D


### PR DESCRIPTION
This PR add support to list images from subscriptions and change the project to support more than one action.


default target (help)
```
❯❯❯ make
Target                         Help message
------                         ------------
export-vm-images               List information about the vm images
export-public-ips              List information about the public ips
help                           Show help
setup                          Build docker image with Azure CLI
```

export-vm-images target
```
❯❯❯ make export-vm-images
"Subscription Name","vm-0","CoreOS","CoreOS","Stable","latest"
"Subscription Name","vm-1","Canonical","UbuntuServer","16.04-LTS","latest"
"Subscription Name","vm-2","Canonical","UbuntuServer","18.04-LTS","latest"
```

export-public-ips target
```
❯❯❯ make export-public-ips
"Subscription Name","vm-0","XXX.XXX.163.121"
"Subscription Name","vm-1","XXX.XXX.67.68"
"Subscription Name","vm-2","XXX.XXX.30.230"
```
