### PR TITLE
Fix Azure Public IP list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@ export-vm-images: setup ## List information about the vm images
 	@$(az-docker-run) \
 		AzureVmImage.sh
 
+.PHONY: export-vm-public-ips
+export-vm-public-ips: setup ## List information about the vm public ips
+	@$(az-docker-run) \
+		AzureVmPublicIP.sh
+
 .PHONY: export-public-ips
 export-public-ips: setup ## List information about the public ips
 	@$(az-docker-run) \

--- a/README.md
+++ b/README.md
@@ -26,13 +26,28 @@ Run this command to build your structure
 $ make setup
 ```
 
-## Getting the IP list
+## Getting the Public IP list
 
 To get the full information from subscriptions, use this command:
 
 ```bash
 $ make export-public-ips
 ```
+
+Output:
+
+```bash
+"Subscription name","public-ip-1","resource-group","xxx.xxx.163.121"
+"Subscription name","public-ip-2","resource-group","xxx.xxx.168.55"
+"Subscription name","public-ip-3","resource-group","xxx.xxx.67.68"
+```
+
+The output contains:
+
+```csv
+"Subscription name","public ip name","resource group","ip address"
+```
+
 If you want only the IP list, use this:
 
 ```bash
@@ -45,6 +60,48 @@ To get the full information from subscriptions, use this command:
 
 ```bash
 $ make export-vm-images
+```
+
+Output:
+
+```bash
+"Subscription Name","vm-0","CoreOS","CoreOS","Stable","latest"
+"Subscription Name","vm-1","Canonical","UbuntuServer","16.04-LTS","latest"
+"Subscription Name","vm-2","Canonical","UbuntuServer","18.04-LTS","latest"
+```
+
+The output contains:
+
+```csv
+"Subscription name","vm name","publisher", "offer", "sku", "version"
+```
+
+## Getting the VM Public IP list
+
+To get the full information from subscriptions, use this command:
+
+```bash
+$ make export-vm-public-ips
+```
+
+Output:
+
+```bash
+"Subscription Name","vm-0","XXX.XXX.163.121"
+"Subscription Name","vm-1","XXX.XXX.67.68"
+"Subscription Name","vm-2","XXX.XXX.30.230"
+```
+
+The output contains:
+
+```csv
+"Subscription name","vm name","ip address"
+```
+
+If you want only the IP list, use this:
+
+```bash
+$ make export-vm-public-ips | awk -F "," '{print $3}'
 ```
 ---
 This commands will read all the Subscriptons where the Service Principal has the access.

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ $ make export-public-ips
 If you want only the IP list, use this:
 
 ```bash
-$ make export-public-ips | awk -F "," '{print $3}'
+$ make export-public-ips | awk -F "," '{print $4}'
 ```
 
 ## Getting the VM Image list

--- a/bin/AzurePublicIP.sh
+++ b/bin/AzurePublicIP.sh
@@ -17,11 +17,12 @@ az login --service-principal --username $AZURE_SERVICE_PRINCIPAL \
 
 # Using JQ to make a magic with the return JSON
 
-JQ_FILTER=".[].virtualMachine |
+JQ_FILTER=".[] |
     {
         name: .name,
-        ip: .network.publicIpAddresses[].ipAddress
-    } | [ .name, .ip ] | @csv"
+        resource: .resourceGroup,
+        ip: .ipAddress
+    } | [ .name, .resource, .ip ] | @csv"
 
 
 # Getting JSON with Subscriptions IDs
@@ -42,11 +43,11 @@ function GetAzurePublicIPs(){
 
     subscription_name=$(az account show | jq --raw-output ".name")
 
-    az vm list-ip-addresses | jq  --raw-output "$JQ_FILTER" | sed "s@^@\"$subscription_name\",@g"
+    az network public-ip list | jq  --raw-output "$JQ_FILTER" | sed "s@^@\"$subscription_name\",@g"
 
 }
 
-# Looping with all the Subscriptions has the Service Principal can acess
+# Looping with all the Subscriptions has the Service Principal can access
 
 for subscription in `GetAzureSubscriptions` ; do
     GetAzurePublicIPs $subscription


### PR DESCRIPTION
The AzurePublicIP actually listed the Public IP addresses of only the VMs. This PR change AzurePublicIP to list all Public IPs.

Now this script return a list with : `Subscription,name,resource group, address`

```
❯❯❯ ./bin/AzurePublicIP.sh                                                                                                              
"Subscription name","public-ip-1","resource-group","xxx.xxx.163.121"                                                                    
"Subscription name","public-ip-2","resource-group","xxx.xxx.168.55"                                                                         
"Subscription name","public-ip-3","resource-group","xxx.xxx.67.68" 
```