### PR TITLE
Add Azure Vm Size list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,6 +18,11 @@ export-vm-public-ips: setup ## List information about the vm public ips
 	@$(az-docker-run) \
 		AzureVmPublicIP.sh
 
+.PHONY: export-vm-sizes
+export-vm-sizes: setup ## List information about the vm sizes
+	@$(az-docker-run) \
+		AzureVmSize.sh
+
 .PHONY: export-public-ips
 export-public-ips: setup ## List information about the public ips
 	@$(az-docker-run) \

--- a/README.md
+++ b/README.md
@@ -103,6 +103,29 @@ If you want only the IP list, use this:
 ```bash
 $ make export-vm-public-ips | awk -F "," '{print $3}'
 ```
+
+## Getting the VM Size list
+
+To get the full information from subscriptions, use this command:
+
+```bash
+$ make export-vm-sizes
+```
+
+Output:
+
+```bash
+"Subscription Name","vm-0","Standard_ds2_v2"
+"Subscription Name","vm-1","Standard_ds2_v2"
+"Subscription Name","vm-2","Standard_ds2_v2"
+```
+
+The output contains:
+
+```csv
+"Subscription name","vm name","vm size"
+```
+
 ---
 This commands will read all the Subscriptons where the Service Principal has the access.
 

--- a/bin/AzureVmSize.sh
+++ b/bin/AzureVmSize.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+# This script using a Service Principal account to generate that list
+
+# Debug bash tags
+
+set -o errexit
+set -o nounset
+
+
+# Making the Azure login
+
+az login --service-principal --username $AZURE_SERVICE_PRINCIPAL \
+    --password $AZURE_CLIENT_SECRET \
+    --tenant $AZURE_TENANT_ID > /dev/null 2>&1
+
+
+# Using JQ to make a magic with the return JSON
+
+JQ_FILTER=".[] |
+    {
+        name: .name,
+        size: .hardwareProfile.vmSize
+    } | [ .name, .size ] | @csv"
+
+
+# Getting JSON with Subscriptions IDs
+
+function GetAzureSubscriptions(){
+
+    az account list | jq --raw-output ".[] | .id"
+}
+
+
+# Getting and cleaning a return JSON with Subscriptions IDs
+
+function GetAzureVMs(){
+
+    subscription=$1
+
+    az account set --subscription $subscription
+
+    subscription_name=$(az account show | jq --raw-output ".name")
+
+    az vm list | jq  --raw-output "$JQ_FILTER" | sed "s@^@\"$subscription_name\",@g"
+
+}
+
+# Looping with all the Subscriptions has the Service Principal can access
+
+for subscription in `GetAzureSubscriptions` ; do
+    GetAzureVMs $subscription
+done


### PR DESCRIPTION
This PR add support to list image sizes from subscriptions

```
❯❯❯ make
Target                         Help message
------                         ------------
export-vm-images               List information about the vm images
export-vm-public-ips           List information about the vm public ips
export-vm-sizes                List information about the vm sizes
export-public-ips              List information about the public ips
help                           Show help
setup                          Build docker image with Azure CLI
```

```bash
$ make export-vm-sizes
```

Output:

```bash
"Subscription Name","vm-0","Standard_ds2_v2"
"Subscription Name","vm-1","Standard_ds2_v2"
"Subscription Name","vm-2","Standard_ds2_v2"
```

The output contains:

```csv
"Subscription name","vm name","vm size"
```